### PR TITLE
[1.20.x] Split Prometheus claim management permissions for players and admins.

### DIFF
--- a/common/src/main/java/earth/terrarium/cadmus/common/commands/claims/ClaimSettingsCommand.java
+++ b/common/src/main/java/earth/terrarium/cadmus/common/commands/claims/ClaimSettingsCommand.java
@@ -52,7 +52,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.BLOCK_BREAKING, ModGameRules.RULE_DO_CLAIMED_BLOCK_BREAKING)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_BLOCK_BREAKING, ModGameRules.RULE_DO_CLAIMED_BLOCK_BREAKING)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 
@@ -88,7 +88,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.BLOCK_PLACING, ModGameRules.RULE_DO_CLAIMED_BLOCK_PLACING)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_BLOCK_PLACING, ModGameRules.RULE_DO_CLAIMED_BLOCK_PLACING)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 
@@ -124,7 +124,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.BLOCK_EXPLOSIONS, ModGameRules.RULE_DO_CLAIMED_BLOCK_EXPLOSIONS)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_BLOCK_EXPLOSIONS, ModGameRules.RULE_DO_CLAIMED_BLOCK_EXPLOSIONS)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 
@@ -160,7 +160,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.BLOCK_INTERACTIONS, ModGameRules.RULE_DO_CLAIMED_BLOCK_INTERACTIONS)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_BLOCK_INTERACTIONS, ModGameRules.RULE_DO_CLAIMED_BLOCK_INTERACTIONS)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 
@@ -196,7 +196,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.ENTITY_INTERACTIONS, ModGameRules.RULE_DO_CLAIMED_ENTITY_INTERACTIONS)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_ENTITY_INTERACTIONS, ModGameRules.RULE_DO_CLAIMED_ENTITY_INTERACTIONS)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 
@@ -232,7 +232,7 @@ public class ClaimSettingsCommand {
                 .executes(context -> {
                     ServerPlayer player = context.getSource().getPlayerOrException();
                     CommandHelper.runAction(() -> {
-                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.ENTITY_DAMAGE, ModGameRules.RULE_CLAIMED_DAMAGE_ENTITIES)) {
+                        if (!checkPrometheusPermissions(player, CadmusAutoCompletes.PERSONAL_ENTITY_DAMAGE, ModGameRules.RULE_CLAIMED_DAMAGE_ENTITIES)) {
                             throw ClaimException.NOT_ALLOWED_TO_MANAGE_SETTINGS;
                         }
 

--- a/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/CadmusAutoCompletes.java
+++ b/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/CadmusAutoCompletes.java
@@ -7,4 +7,10 @@ public class CadmusAutoCompletes {
     public static final String BLOCK_INTERACTIONS = "cadmus.block_interactions";
     public static final String ENTITY_INTERACTIONS = "cadmus.entity_interactions";
     public static final String ENTITY_DAMAGE = "cadmus.entity_damage";
+    public static final String PERSONAL_BLOCK_BREAKING = "cadmus.personal.block_breaking";
+    public static final String PERSONAL_BLOCK_PLACING = "cadmus.personal.block_placing";
+    public static final String PERSONAL_BLOCK_EXPLOSIONS = "cadmus.personal.block_explosions";
+    public static final String PERSONAL_BLOCK_INTERACTIONS = "cadmus.personal.block_interactions";
+    public static final String PERSONAL_ENTITY_INTERACTIONS = "cadmus.personal.entity_interactions";
+    public static final String PERSONAL_ENTITY_DAMAGE = "cadmus.personal.entity_damage";
 }

--- a/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/PrometheusIntegration.java
+++ b/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/PrometheusIntegration.java
@@ -25,6 +25,12 @@ public class PrometheusIntegration {
         api.addAutoComplete(CadmusAutoCompletes.BLOCK_INTERACTIONS);
         api.addAutoComplete(CadmusAutoCompletes.ENTITY_INTERACTIONS);
         api.addAutoComplete(CadmusAutoCompletes.ENTITY_DAMAGE);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_BLOCK_BREAKING);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_BLOCK_PLACING);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_BLOCK_EXPLOSIONS);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_BLOCK_INTERACTIONS);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_ENTITY_INTERACTIONS);
+        api.addAutoComplete(CadmusAutoCompletes.PERSONAL_ENTITY_DAMAGE);
 
         OptionDisplayApi.API.register(CadmusOptions.SERIALIZER.id(), CadmusOptionsDisplay::create);
     }


### PR DESCRIPTION
Adds new `cadmus.personal` equivalents of the existing Prometheus claim management permissions to be used specifically for giving players permission to manage the settings of their own claims.

closes #26