### PR TITLE
Fix Unclaim All from map, Prometheus crash and update gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,24 +57,26 @@ subprojects {
     }
 
     dependencies {
+        val minecraftVersion: String by project
+        val minecraftVersionFull: String by project
         val prometheusVersion: String by project
+        val resourcefulLibVersion: String by project
+        val olympusVersion: String by project
         val reiVersion: String by project
         val journeymapVersion: String by project
         val journeymapApiVersion: String by project
+        val parchmentVersion: String by project
 
         "minecraft"("::$minecraftVersion")
 
         @Suppress("UnstableApiUsage")
         "mappings"(project.the<LoomGradleExtensionAPI>().layered {
-            val parchmentVersion: String by project
-
             officialMojangMappings()
-
-            parchment(create(group = "org.parchmentmc.data", name = "parchment-1.21", version = parchmentVersion))
+            parchment(create(group = "org.parchmentmc.data", name = "parchment-$minecraftVersion", version = parchmentVersion))
         })
 
-        "modApi"(group = "com.teamresourceful.resourcefullib", name = "resourcefullib-$modLoader-$minecraftVersion", version = "3.0.12")
-        val olympus = "modImplementation"(group = "earth.terrarium.olympus", name = "olympus-$modLoader-$minecraftVersion", version = "1.0.9") {
+        "modApi"(group = "com.teamresourceful.resourcefullib", name = "resourcefullib-$modLoader-$minecraftVersion", version = resourcefulLibVersion)
+        val olympus = "modImplementation"(group = "earth.terrarium.olympus", name = "olympus-$modLoader-$minecraftVersion", version = olympusVersion) {
             isTransitive = false
         }
 
@@ -94,7 +96,7 @@ subprojects {
             "modCompileOnly"(group = "me.shedaniel", name = "RoughlyEnoughItems-default-plugin-$modLoader", version = reiVersion)
             "include"(olympus)
 
-            // "modRuntimeOnly"(group = "maven.modrinth", name = "journeymap", version = "$journeymapVersion+$modLoader")
+            // "modRuntimeOnly"(group = "maven.modrinth", name = "journeymap", version = "${minecraft_version_full}-$journeymapVersion+$modLoader")
             // "modRuntimeOnly"(group = "maven.modrinth", name = "common-network", version = project.properties["commonNetwork${modLoader}Version"] as String)
         }
     }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,6 +12,10 @@ repositories {
 }
 
 dependencies {
-    modCompileOnly(group = "tech.thatgravyboat", name = "commonats", version = "2.0")
-    modCompileOnly(group = "maven.modrinth", name = "xaeros-world-map", version = "1.39.0_Fabric_1.21")
+    val xaerosWorldMapVersion: String by project
+    val commonatsVersion: String by project
+    val minecraftVersion: String by project
+
+    modCompileOnly(group = "tech.thatgravyboat", name = "commonats", version = commonatsVersion)
+    modCompileOnly(group = "maven.modrinth", name = "xaeros-world-map", version = "${xaerosWorldMapVersion}_Fabric_$minecraftVersion")
 }

--- a/common/src/main/java/earth/terrarium/cadmus/client/ClaimMapScreen.java
+++ b/common/src/main/java/earth/terrarium/cadmus/client/ClaimMapScreen.java
@@ -1,7 +1,5 @@
 package earth.terrarium.cadmus.client;
 
-import com.mojang.math.Axis;
-import com.teamresourceful.resourcefullib.client.CloseablePoseStack;
 import com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen;
 import com.teamresourceful.resourcefullib.client.utils.ScreenUtils;
 import com.teamresourceful.resourcefullib.common.color.Color;
@@ -33,7 +31,6 @@ import earth.terrarium.olympus.client.ui.UIConstants;
 import earth.terrarium.olympus.client.ui.UIIcons;
 import earth.terrarium.olympus.client.ui.modals.DeleteConfirmModal;
 import earth.terrarium.olympus.client.utils.State;
-import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -45,14 +42,12 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
 public class ClaimMapScreen extends BaseCursorScreen {
-    public static final ResourceLocation MAP_ICONS = ResourceLocation.withDefaultNamespace("textures/map/decorations/player.png");
     public static final int MAP_SIZE = 192;
     public static final int BANNER_HEIGHT = 15;
     public static final int BUTTON_HEIGHT = 24;
@@ -220,8 +215,6 @@ public class ClaimMapScreen extends BaseCursorScreen {
         } else {
             drawSelection(graphics);
         }
-
-        renderPlayerAvatar(graphics);
     }
 
     private void drawClaimLabels(GuiGraphics graphics) {
@@ -419,27 +412,6 @@ public class ClaimMapScreen extends BaseCursorScreen {
         graphics.fill(roundedX, roundedY, roundedWidth, roundedHeight, 2, color & 0x33ffffff);
     }
 
-    private void renderPlayerAvatar(GuiGraphics graphics) {
-        float left = (this.width) / 2f;
-        float top = (this.height) / 2f;
-
-        double playerX = player.getX();
-        double playerZ = player.getZ();
-        double x = (playerX % 16) + (playerX >= 0 ? -8 : 8);
-        double y = (playerZ % 16) + (playerZ >= 0 ? -8 : 8);
-
-        float scale = MAP_SIZE / (getMapScale() * 2f + 16);
-
-        x *= scale;
-        y *= scale;
-        try (var pose = new CloseablePoseStack(graphics)) {
-            pose.translate(left + x, top + y, 0);
-            pose.mulPose(Axis.ZP.rotationDegrees(player.getYRot() + 180));
-            pose.translate(-4, -4, 2);
-            graphics.blit(MAP_ICONS, 0, 0, 40, 0, 8, 8, 128, 128);
-        }
-    }
-
     private void doAction(int startX, int endX, int startZ, int endZ, int button) {
         if (startX == 0 && startZ == 0) return;
         ChunkPos startPos = new ChunkPos(startX, startZ);
@@ -490,12 +462,6 @@ public class ClaimMapScreen extends BaseCursorScreen {
         return scale - (scale % 16) + 16;
     }
 
-    public int getMapScale() {
-        int scale = Minecraft.getInstance().options.renderDistance().get() * 8;
-        return scale - scale % 16 + 16;
-    }
-
-
     private void claim(ChunkPos pos, boolean chunkLoad) {
         CadmusClient.sendClaimCommand(ClaimCommandType.CLAIM, selected.get(), "%s %s %s".formatted(pos.getMaxBlockX(), pos.getMaxBlockZ(), chunkLoad));
     }
@@ -513,7 +479,7 @@ public class ClaimMapScreen extends BaseCursorScreen {
     }
 
     private void unclaimAll() {
-        DeleteConfirmModal.open(ConstantComponents.UNCLAIM_MODAL_TITLE, ConstantComponents.UNCLAIM_MODAL_DESCRIPTION, ConstantComponents.UNCLAIM_MODAL_CONFIRM, () -> CadmusClient.sendClaimCommand(ClaimCommandType.UNCLAIM, selected.get(), selected.get().asArg()));
+        DeleteConfirmModal.open(ConstantComponents.UNCLAIM_MODAL_TITLE, ConstantComponents.UNCLAIM_MODAL_DESCRIPTION, ConstantComponents.UNCLAIM_MODAL_CONFIRM, () -> CadmusClient.sendTeamlessClaimCommand(ClaimCommandType.UNCLAIM, selected.get().asArg()));
     }
 
     private static void update() {

--- a/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/PrometheusCompat.java
+++ b/common/src/main/java/earth/terrarium/cadmus/common/compat/prometheus/PrometheusCompat.java
@@ -9,7 +9,6 @@ import earth.terrarium.prometheus.api.permissions.PermissionApi;
 import earth.terrarium.prometheus.api.roles.options.RoleOptionsApi;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 
 public class PrometheusCompat {
 

--- a/common/src/main/java/earth/terrarium/cadmus/common/utils/ModUtils.java
+++ b/common/src/main/java/earth/terrarium/cadmus/common/utils/ModUtils.java
@@ -3,7 +3,10 @@ package earth.terrarium.cadmus.common.utils;
 import com.teamresourceful.resourcefullib.common.color.Color;
 import com.teamresourceful.resourcefullib.common.exceptions.NotImplementedException;
 import com.teamresourceful.resourcefullib.common.utils.CommonUtils;
+import com.teamresourceful.resourcefullib.common.utils.modinfo.ModInfo;
+import com.teamresourceful.resourcefullib.common.utils.modinfo.ModInfoUtils;
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import earth.terrarium.cadmus.Cadmus;
 import earth.terrarium.cadmus.api.claims.ClaimApi;
 import earth.terrarium.cadmus.api.protections.ProtectionApi;
 import earth.terrarium.cadmus.api.teams.TeamApi;
@@ -103,7 +106,8 @@ public class ModUtils {
         if (!player.hasPermissions(2)) {
             if (!TeamApi.API.canModifySettings(player, id)) {
                 return ConstantComponents.NO_PERMISSION_TEAM;
-            } else if (player.getServer() == null || !PrometheusCompat.hasPermission(player.getServer(), player.getGameProfile(), protection.permission())) {
+
+            } else if (player.getServer() == null || (Cadmus.IS_PROMETHEUS_LOADED && !PrometheusCompat.hasPermission(player.getServer(), player.getGameProfile(), protection.permission()))) {
                 return ConstantComponents.NO_PERMISSION_ROLE;
             }
         }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -29,11 +29,13 @@ dependencies {
     val fabricLoaderVersion: String by project
     val fabricApiVersion: String by project
     val commonProtectionApiVersion: String by project
+    val xaerosWorldMapVersion: String by project
+    val xaerosMiniMapVersion: String by project
 
     modImplementation(group = "net.fabricmc", name = "fabric-loader", version = fabricLoaderVersion)
     modApi(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "$fabricApiVersion+$minecraftVersion")
     include(modImplementation(group = "eu.pb4", name = "common-protection-api", version = commonProtectionApiVersion))
 
-    // modLocalRuntime(group = "maven.modrinth", name = "xaeros-world-map", version = "1.39.0_Fabric_1.21")
-    // modLocalRuntime(group = "maven.modrinth", name = "xaeros-minimap", version = "24.3.0_Fabric_1.21")
+    // modLocalRuntime(group = "maven.modrinth", name = "xaeros-world-map", version = "${xaerosWorldMapVersion}_Fabric_$minecraftVersion")
+    // modLocalRuntime(group = "maven.modrinth", name = "xaeros-minimap", version = "${xaerosMiniMapVersion}_Fabric_$minecraftVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,17 +2,27 @@ org.gradle.jvmargs=-Xmx2G
 
 enabledPlatforms=fabric,neoforge
 
-version=2.0.0-alpha.5
+version=2.0.0-alpha.6
 group=earth.terrarium.cadmus
 
 minecraftVersion=1.21
+minecraftVersionFull=1.21.1
 parchmentVersion=2024.07.28
 
+# Libraries
 resourcefulLibVersion=3.0.12
+olympusVersion=1.0.13
+commonatsVersion=2.0
+byteCodecsVersion=1.0.2
 
-reiVersion=16.0.754
-journeymapVersion=1.21.1-6.0.0-beta.39
+# Mod Compatibility
+prometheusVersion=2.0.0
+reiVersion=16.0.799
+journeymapVersion=6.0.0-beta.52
 journeymapApiVersion=2.0.0-1.21-SNAPSHOT
+xaerosWorldMapVersion=1.39.0
+xaerosMiniMapVersion=24.3.0
+
+# Misc
 commonNetworkneoforgeVersion=QYLtKTFr
 commonNetworkfabricVersion=JfV4uInx
-prometheusVersion=2.0.0

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -18,12 +18,14 @@ dependencies {
 
     val minecraftVersion: String by project
     val neoforgeVersion: String by project
-    val reiVersion: String by project
+    val xaerosWorldMapVersion: String by project
+    val xaerosMiniMapVersion: String by project
+    val byteCodecsVersion: String by project
 
     neoForge(group = "net.neoforged", name = "neoforge", version = neoforgeVersion)
 
-    forgeRuntimeLibrary("com.teamresourceful:bytecodecs:1.0.2")
+    forgeRuntimeLibrary(group = "com.teamresourceful", name = "bytecodecs", version = byteCodecsVersion)
 
-    modLocalRuntime(group = "maven.modrinth", name = "xaeros-world-map", version = "1.39.0_NeoForge_1.21")
-    modLocalRuntime(group = "maven.modrinth", name = "xaeros-minimap", version = "24.3.0_NeoForge_1.21")
+    modLocalRuntime(group = "maven.modrinth", name = "xaeros-world-map", version = "${xaerosWorldMapVersion}_NeoForge_$minecraftVersion")
+    modLocalRuntime(group = "maven.modrinth", name = "xaeros-minimap", version = "${xaerosMiniMapVersion}_NeoForge_$minecraftVersion")
 }


### PR DESCRIPTION
- Added a dependency check for Prometheus within `ModUtils` so it doesn't crash when the mod isn't present on a server and a player tries to access the map claim screen.
- Removed redundant code for the player marker that is now handled by a seperate widget. See: https://github.com/terrarium-earth/Olympus/pull/42#issue-3577050885 to fix the player marker rotation.
- Updated gradle as best as I can. It's only a partial update of some dependencies so it's not perfect yet.